### PR TITLE
fix: prevent Range error at the end of a file

### DIFF
--- a/src/CompletionProvider.js
+++ b/src/CompletionProvider.js
@@ -22,8 +22,8 @@ class CompletionProvider {
     const before = document.getTextInRange(new Range(0, cursorPosition))
     // text after cursor
     const after = document.getTextInRange(
-      new Range(cursorPosition, document.length - 1)
-    )
+      new Range(cursorPosition, Math.max(cursorPosition, document.length - 1))
+    );
 
     // construct request
     const request = {


### PR DESCRIPTION
The cursorPosition can be equal to the document length if it’s at the very end of the file.

Fixes this error:

```
Extension encountered an uncaught exception:
/Users/nate/Library/Application Support/Nova/Extensions/alexanderflink.tabnine/Scripts/main.js (Line 27, Column 0)
Error: End index of range must not precede start index
    NovaJSRange@[native code]
    provideCompletionItems@file:///Users/nate/Library/Application%20Support/Nova/Extensions/alexanderflink.tabnine/Scripts/main.js:27:16

TabNine issues may be reported at https://github.com/alexanderflink/nova-tabnine/issues
```